### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,13 +28,13 @@ for display by a Raspberry Pi. With the Pi's rather slow ARMv6 processor, both
 Wand and PIL were too slow to be usable.
 
 .. _wand-py: http://wand-py.org
-.. _PIL/PIllow: http://pillow.readthedocs.org
-.. _Benchmarks: http://jpegtran-cffi.readthedocs.org/en/latest/#benchmarks
+.. _PIL/PIllow: https://pillow.readthedocs.io
+.. _Benchmarks: https://jpegtran-cffi.readthedocs.io/en/latest/#benchmarks
 .. _epeg library: https://github.com/mattes/epeg
 .. _libturbojpeg: http://www.libjpeg-turbo.org/About/TurboJPEG
 .. _libjpeg-turbo: http://www.libjpeg-turbo.org/
-.. _CFFI: http://cffi.readthedocs.org
-.. _spreads: http://spreads.readthedocs.org
+.. _CFFI: https://cffi.readthedocs.io
+.. _spreads: https://spreads.readthedocs.io
 
 Requirements
 ============
@@ -100,7 +100,7 @@ Usage
 
 For more details, refer to the `API Reference`_.
 
-.. _API Reference: http://jpegtran-cffi.readthedocs.org/en/latest/#api-reference
+.. _API Reference: https://jpegtran-cffi.readthedocs.io/en/latest/#api-reference
 
 Benchmarks
 ==========
@@ -109,7 +109,7 @@ HDD with the following 2560x1920 8bit RGB JPEG:
 
 http://upload.wikimedia.org/wikipedia/commons/8/82/Mandel_zoom_05_tail_part.jpg
 
-.. figure:: http://jpegtran-cffi.readthedocs.org/en/latest/_images/benchmark.png
+.. figure:: https://jpegtran-cffi.readthedocs.io/en/latest/_images/benchmark.png
 
     Both wand-py and PIL were run with the fastest scaling algorithm available,
     for wand-py this meant using ``Image.sample`` instead of ``Image.resize``

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,11 +30,11 @@ The source code is under the MIT license and can be found on GitHub_.
 
 .. _jpegtran_cffi: http://github.com/jbaiter/jpegtran-cffi
 .. _wand-py: http://wand-py.org
-.. _PIL/PIllow: http://pillow.readthedocs.org
+.. _PIL/PIllow: https://pillow.readthedocs.io
 .. _epeg library: https://github.com/mattes/epeg
 .. _libjpeg: http://en.wikipedia.org/wiki/Libjpeg
-.. _CFFI: http://cffi.readthedocs.org
-.. _spreads: http://spreads.readthedocs.org
+.. _CFFI: https://cffi.readthedocs.io
+.. _spreads: https://spreads.readthedocs.io
 .. _GitHub: http://github.com/jbaiter/jpegtran-cffi
 
 Requirements


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
