### PR TITLE
No fatal error on extraneous bytes

### DIFF
--- a/jpegtran/lib.py
+++ b/jpegtran/lib.py
@@ -151,8 +151,11 @@ def jpegtran_op(func):
         rv = lib.tjTransform(tjhandle, in_data_p, in_data_len, 1,
                              out_bufs, out_sizes, transformoption, 0)
         if rv < 0:
-            raise Exception("Transformation failed: {0}"
-                            .format(ffi.string(lib.tjGetErrorStr())))
+            err_str =  ffi.string(lib.tjGetErrorStr()).decode('ascii')
+            if "extraneous bytes before marker" in err_str:
+                print("Warning: {0}".format(err_str))
+            else:
+                raise Exception("Transformation failed: {0}".format(err_str))
 
         _weak_keydict[out_bufs[0]] = out_bufs
         return bytearray(ffi.buffer(out_bufs[0], out_sizes[0])[:])


### PR DESCRIPTION
The library should not throw fatal error when encountering the "extraneous bytes before marker 0xd9" warning. This is a minor warning and jpegtran produces correct files after transformation.