### PR TITLE
Build wheels for Linux and Windows on Github actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,81 @@
+name: Python package
+
+on:
+  push:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels_linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.12.3
+      env:
+        CIBW_BEFORE_ALL: "sh linux-build.sh"
+        CIBW_BEFORE_BUILD: echo {project}/binaries
+        CIBW_SKIP: "cp36-* pp*"
+        CIBW_ARCHS_LINUX: auto64
+        CIBW_REPAIR_WHEEL_COMMAND: "LD_LIBRARY_PATH=/project/binaries auditwheel repair -w {dest_dir} {wheel}"
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./wheelhouse/*.whl
+
+  build_wheels_windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch:
+          - AMD64
+          - x86
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.8' 
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+    - name: Build dependencies
+      shell: cmd
+      run: |
+        python get-nasm.py ${{ matrix.arch }}
+        set path=%path%;%CD%\nasm-2.14.02
+        mkdir binaries
+        cd binaries
+        cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ../libjpeg-turbo
+        nmake
+        cd ..
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.12.3
+      env:
+        CIBW_SKIP: cp36-* pp*
+        CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
+        CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "python -m delvewheel repair -w {dest_dir} {wheel} --add-path binaries"
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./wheelhouse/*.whl
+
+
+  upload-pypi:
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: [build_wheels_linux, build_wheels_windows]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -75,7 +75,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 __pycache__
 doc/_*
+
+build/
+binaries/
+CMakeFiles/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libjpeg-turbo"]
+	path = libjpeg-turbo
+	url = https://github.com/libjpeg-turbo/libjpeg-turbo
+	branch = main

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Wand and PIL were too slow to be usable.
 .. _PIL/PIllow: https://pillow.readthedocs.io
 .. _Benchmarks: https://jpegtran-cffi.readthedocs.io/en/latest/#benchmarks
 .. _epeg library: https://github.com/mattes/epeg
-.. _libturbojpeg: http://www.libjpeg-turbo.org/About/TurboJPEG
+.. _turbojpeg: http://www.libjpeg-turbo.org/About/TurboJPEG
 .. _libjpeg-turbo: http://www.libjpeg-turbo.org/
 .. _CFFI: https://cffi.readthedocs.io
 .. _spreads: https://spreads.readthedocs.io

--- a/get-nasm.py
+++ b/get-nasm.py
@@ -1,0 +1,28 @@
+import urllib.request
+from argparse import ArgumentParser
+from pathlib import Path
+from zipfile import ZipFile
+
+urls = {
+    "amd64": "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip",
+    "x86": "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win32/nasm-2.14.02-win32.zip",
+}
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("arch", type=str.lower, choices=urls.keys())
+    parser.add_argument("--zip-name", default="nasm.zip")
+    args = parser.parse_args()
+
+    url = urls[args.arch]
+    urllib.request.urlretrieve(url, args.zip_name)
+
+    with ZipFile(args.zip_name, "r") as zip:
+        zip.extractall()
+
+    assert Path("nasm-2.14.02").exists()
+
+
+if __name__ == "__main__":
+    main()

--- a/jpegtran/jpegtran_build.py
+++ b/jpegtran/jpegtran_build.py
@@ -12,13 +12,17 @@ SOURCE = """
 #include "turbojpeg.h"
 """
 
+static_lib_dir = 'binaries'
+
 ffi = FFI()
 ffi.set_source(
     "_jpegtran", SOURCE,
     sources=["src/epeg.c"],
-    include_dirs=["src"],
+    include_dirs=["src", "libjpeg-turbo", static_lib_dir],
     define_macros=[("HAVE_UNSIGNED_CHAR", "1")],
-    libraries=["jpeg", "turbojpeg"])
+    libraries=['jpeg', 'turbojpeg'],
+    library_dirs=[static_lib_dir],
+)
 ffi.cdef(CDEF)
 
 if __name__ == "__main__":

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -1,5 +1,7 @@
 yum makecache
 yum -y install nasm
+apk update
+apk add --upgrade nasm
 python -m pip install -U pip wheel
 python -m pip install -U cmake
 mkdir binaries

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -1,0 +1,10 @@
+yum makecache
+yum -y install nasm
+python -m pip install -U pip wheel
+python -m pip install -U cmake
+mkdir binaries
+cd binaries
+cmake -G"Unix Makefiles" ../libjpeg-turbo
+make
+cd ..
+ls binaries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "cffi >= 1.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ transformation operations work directly with the JPEG data.
 """
 
 setup(
-    name='jpegtran-cffi',
+    name='jpegtran-cffi-wheels',
     version="0.5.3.dev",
     description=("Extremly fast, (mostly) lossless JPEG transformations"),
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from setuptools import setup
 
 if os.path.exists('README.rst'):
     if sys.version_info > (3,):
-        description_long = open('README.rst', encoding="utf-8").read()
+        long_description = open('README.rst', encoding="utf-8").read()
     else:
-        description_long = open('README.rst').read()
+        long_description = open('README.rst').read()
 else:
-    description_long = """
+    long_description = """
 A Python package for blazingly fast JPEG transformations. Compared to other,
 more general purpose image processing libraries like `wand-py`_  or
 `PIL/Pillow`_, the performance gain can, depending on the transformation, be
@@ -23,14 +23,13 @@ setup(
     name='jpegtran-cffi',
     version="0.5.3.dev",
     description=("Extremly fast, (mostly) lossless JPEG transformations"),
-    description_long=description_long,
+    long_description=long_description,
     author="Johannes Baiter",
     url="http://github.com/jbaiter/jpegtran-cffi.git",
     author_email="johannes.baiter@gmail.com",
     license='MIT',
     packages=['jpegtran'],
     package_data={'jpegtran': ['jpegtran.cdef']},
-    setup_requires=['cffi >= 1.0'],
     install_requires=['cffi >= 1.0'],
     cffi_modules=["jpegtran/jpegtran_build.py:ffi"]
 )


### PR DESCRIPTION
I created a workflow to build wheel files for Linux and Windows automatically on Github actions.
To support multiple platforms easily, I included the `libjpeg-turbo` repo as a submodule and build it so it can be linked.
Because of that the `jpegtran_build.py` file changed slightly to find the necessary objects.

It should be easy to add MacOS builds as well, but I have zero experience with MacOS. So maybe somebody else can add it later. Also building it on 32bit linux platforms causes issues with the assembler so I didn't include it for now. Building turbojpeg without NASM worked, so I don't know if the issue is with NASM or turbojpeg.

For testing I changed the name of the package to `jpegtran-cffi-wheels`, so I can do real testing. You can see the results here <https://pypi.org/project/jpegtran-cffi-wheels/>. If you would like to merge it you should change it back first.

Also it requires the `pypi_password` to be set in the repository secrets config.
I also fixed some tiny issues with the readme file for pypi.