### PR TITLE
Find header and libraries of libjpeg-turbo in conda enviroment

### DIFF
--- a/jpegtran/jpegtran_build.py
+++ b/jpegtran/jpegtran_build.py
@@ -12,13 +12,24 @@ SOURCE = """
 #include "turbojpeg.h"
 """
 
+include_dirs = ["src"]
+library_dirs = []
+
+conda_prefix = os.environ.get("CONDA_PREFIX")
+
+if conda_prefix:
+    library = os.path.join(conda_prefix, "Library")
+    include_dirs.append(os.path.join(library, "include"))
+    library_dirs.append(os.path.join(library, "lib"))
+
 ffi = FFI()
 ffi.set_source(
     "_jpegtran", SOURCE,
     sources=["src/epeg.c"],
-    include_dirs=["src"],
+    include_dirs=include_dirs,
     define_macros=[("HAVE_UNSIGNED_CHAR", "1")],
-    libraries=["jpeg", "turbojpeg"])
+    libraries=["jpeg", "turbojpeg"],
+    library_dirs=library_dirs)
 ffi.cdef(CDEF)
 
 if __name__ == "__main__":


### PR DESCRIPTION
On Windows in a base conda environment with libjpeg-turbo I only succeed in installing jpegtran-cffi with the following command: pip install git+https://github.com/jbaiter/jpegtran-cffi.git --global-option="build_ext" --global-option="-I%USERPROFILE%\anaconda3\Library\include" --global-option="-L%USERPROFILE%\anaconda3\Library\lib"

This commit adds the include_dirs and library_dirs to a conda environment if the CONDA_PREFIX is found. Then the following command works: pip install git+https://github.com/BobbyCephy/jpegtran-cffi.git