### PR TITLE
Automatically find libjpeg-turbo headers and libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 __pycache__
 doc/_*
+build
+*egg*

--- a/jpegtran/jpegtran_build.py
+++ b/jpegtran/jpegtran_build.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from cffi import FFI
 
@@ -12,13 +13,24 @@ SOURCE = """
 #include "turbojpeg.h"
 """
 
+include_dirs = ["src"]
+library_dirs = []
+
+jpegtran = shutil.which("jpegtran")
+
+if jpegtran:
+    prefix = os.path.dirname(os.path.dirname(jpegtran))
+    include_dirs.append(os.path.join(prefix, "include"))
+    library_dirs.append(os.path.join(prefix, "lib"))
+
 ffi = FFI()
 ffi.set_source(
     "_jpegtran", SOURCE,
     sources=["src/epeg.c"],
-    include_dirs=["src"],
+    include_dirs=include_dirs,
     define_macros=[("HAVE_UNSIGNED_CHAR", "1")],
-    libraries=["jpeg", "turbojpeg"])
+    libraries=["jpeg", "turbojpeg"],
+    library_dirs=library_dirs)
 ffi.cdef(CDEF)
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the jpegtran executable is found in the PATH, the relative directories of the headers and libraries of libjpeg-turbo can be found automatically. Solves #41.